### PR TITLE
Fix unsafe repo in entrypoint.fish

### DIFF
--- a/entrypoint.fish
+++ b/entrypoint.fish
@@ -205,7 +205,6 @@ function git_pull_to_dir -a "user" "email" "repo_url" "branch" "target_dir" "dry
         git clone -b "$branch" "$repo_url" --depth=1 .
         and git config user.email "$email"
         and git config user.name "$user"
-        and git config --global --add safe.directory /github/workspace # Fix for the unsafe repo error: https://github.com/dertdog/external-repo-sync-action/issues/1
         or begin; error "Error during pulling"; exit 1; end
     else
         inform "Using dry-run, no repo data will be pulled."
@@ -271,6 +270,9 @@ set branch (load_branch "$_flag_branch")
 set repo_url (parse_url "$repo" "$token")
 
 set tmp_dir (mktemp -d)
+# Fix for the unsafe repo error: https://github.com/dertdog/external-repo-sync-action/issues/1
+#echo "git config --global --add safe.directory $tmp_dir"
+git config --global --add safe.directory "$tmp_dir"
 git_pull_to_dir "$user" "$email" "$repo_url" "$branch" "$tmp_dir" "$_flag_dry_run"
 set exclude_option (build_exclude_option "$_flag_exclude_patterns")
 set include_option (build_include_option "$_flag_include_patterns")

--- a/entrypoint.fish
+++ b/entrypoint.fish
@@ -271,7 +271,7 @@ set repo_url (parse_url "$repo" "$token")
 
 set tmp_dir (mktemp -d)
 # Fix for the unsafe repo error: https://github.com/dertdog/external-repo-sync-action/issues/1
-#echo "git config --global --add safe.directory $tmp_dir"
+echo "git config --global --add safe.directory $tmp_dir"
 git config --global --add safe.directory "$tmp_dir"
 git_pull_to_dir "$user" "$email" "$repo_url" "$branch" "$tmp_dir" "$_flag_dry_run"
 set exclude_option (build_exclude_option "$_flag_exclude_patterns")

--- a/entrypoint.fish
+++ b/entrypoint.fish
@@ -205,6 +205,7 @@ function git_pull_to_dir -a "user" "email" "repo_url" "branch" "target_dir" "dry
         git clone -b "$branch" "$repo_url" --depth=1 .
         and git config user.email "$email"
         and git config user.name "$user"
+        and git config --global --add safe.directory /github/workspace # Fix for the unsafe repo error: https://github.com/dertdog/external-repo-sync-action/issues/1
         or begin; error "Error during pulling"; exit 1; end
     else
         inform "Using dry-run, no repo data will be pulled."


### PR DESCRIPTION
Add `git config --global --add safe.directory /github/workspace` to fix https://github.com/dertdog/external-repo-sync-action/issues/1